### PR TITLE
Add a page about the John Pinner award

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Using Python
 
 This site uses django-amber_. To install django-amber and other dependencies, run ``pip install -r requirements.txt``.  django-amber is only known to work with Python 3.5+.
 
-You must also install `less <https://www.npmjs.com/package/less>`_, and ensure that `lessc` is available in your PATH. The version of lessc packaged in Ubuntu 16.04 is not sufficient (it's probably too old)
+You must also install `less <https://www.npmjs.com/package/less>`_, and ensure that `lessc` is available in your PATH. The version of lessc packaged in Ubuntu 16.04 is not sufficient (it's probably too old). Instead, use apt-get to install npm and type: ``sudo npm install -g less``
 
 django-amber builds the site by assembling several components:
 

--- a/pages/pinner-award.md
+++ b/pages/pinner-award.md
@@ -24,7 +24,7 @@ the personification of a Pythonista who gave time, code and effort back to the
 community. He was a role model, mentor and teacher who is sorely missed by
 many.
 
-With the blessing of the Pinner family, the UKPA instigating an award to
+With the blessing of the Pinner family, the UKPA is initiating the award to
 honour and remember John's extraordinary contribution to our community.
 
 <h2>How?</h2>

--- a/pages/pinner-award.md
+++ b/pages/pinner-award.md
@@ -40,12 +40,10 @@ each nomination meets the requirements outlined above (specifically, that the
 nomination is for Python related community service in the UK and the nominator
 is a real person).
 
-To win an award a person needs to have at least three separate nominations. The
-recipients of the award will be the three most nominated people in any
-particular annual nomination period of the award. In the case of a tie, there
-will be joint winners with the possibility of more than three awards being
-made in any run of the award to ensure all those with enough votes receive an
-award.
+The recipients of the award will be the three most nominated people in any
+annual nomination period of the award. In the case of a tie, all joint winners
+in the top three slots will receive an award. Finally, a nominee isn't eligable
+until three *separate nominations* are received in support of them.
 
 <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSdWFta61RMBmxgPEpZghorFzSpKCkyabVgRAJMbyMt2ARF0oQ/viewform?embedded=true" width="100%" height="1600" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>
 

--- a/pages/pinner-award.md
+++ b/pages/pinner-award.md
@@ -1,0 +1,51 @@
+title: The John Pinner Award
+---
+<h2>What?</h2>
+
+The annual John Pinner award celebrates voluntary service to the Python
+community in the UK. It's for those who freely contribute time and effort for
+the good of the community but who generally don't get the sort of recognition
+others may enjoy.
+
+This is an annual award with up to three awards being given at once. The awards
+will be announced at the start of each annual PyCon UK conference, so
+recipients at the conference may enjoy a weekend of recognition from the wider
+community in attendence.
+
+It is only possible to win the award once.
+
+Recipients of the award will receive a free ticket to next year's PyCon UK and
+a token in recognition of their efforts (most likely a medal of some sort).
+
+<h2>Why?</h2>
+
+John Pinner founded and organised PyCon UK until he passed away in 2015. He was
+the personification of a Pythonista who gave time, code and effort back to the
+community. He was a role model, mentor and teacher who is sorely missed by
+many.
+
+With the blessing of the Pinner family, the UKPA instigating an award to
+honour and remember John's extraordinary contribution to our community.
+
+<h2>How?</h2>
+
+The award is administered by at least two returning officers. The returning
+officers may not receive the award and any nominations for them will be
+discarded. For this year the returning officers are Nicholas Tollervey and
+Peter Inglesby.
+
+Nominations from the wider Python UK community are made simply by filling in
+the form embedded below. The returning officers will confirm
+each nomination meets the requirements outlined above (specifically, that the
+nomination is for Python related community service in the UK and the nominator
+is a real person).
+
+To win an award a person needs to have at least three separate nominations. The
+recipients of the award will be the three most nominated people in any
+particular annual nomination period of the award.
+
+<iframe src="https://docs.google.com/forms/d/e/1FAIpQLSdWFta61RMBmxgPEpZghorFzSpKCkyabVgRAJMbyMt2ARF0oQ/viewform?embedded=true" width="100%" height="1600" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>
+
+If required, the private records associated with this process can be made
+available (in the form of a spreadsheet) upon request to the returning
+officers. A list of recipients will be kept on the UKPA website.

--- a/pages/pinner-award.md
+++ b/pages/pinner-award.md
@@ -42,7 +42,10 @@ is a real person).
 
 To win an award a person needs to have at least three separate nominations. The
 recipients of the award will be the three most nominated people in any
-particular annual nomination period of the award.
+particular annual nomination period of the award. In the case of a tie, there
+will be joint winners with the possibility of more than three awards being
+made in any run of the award to ensure all those with enough votes receive an
+award.
 
 <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSdWFta61RMBmxgPEpZghorFzSpKCkyabVgRAJMbyMt2ARF0oQ/viewform?embedded=true" width="100%" height="1600" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>
 


### PR DESCRIPTION
As requested by @inglesp, the page for the John Pinner award on the PyCon UK website.

I've included the most basic and simple, what, why and how information along with a responsive embedded Google form for collecting nominations. I'll share the form with @inglesp via email once I've submitted this PR.

Finally, I added instructions for installing `lessc` on Ubuntu to the README - apologies for the combined PR.

**TODO**: This page needs linking to from the main website, and announcing too. I'll leave that to @inglesp to coordinate (as agreed).