### PR TITLE
Revert "Add link to shop"

### DIFF
--- a/redirections/shop.yml
+++ b/redirections/shop.yml
@@ -1,1 +1,0 @@
-new_url: https://shop.spreadshirt.co.uk/pyconuk/

--- a/templates/base.html
+++ b/templates/base.html
@@ -32,7 +32,6 @@
         <li><a href="/venue/">Venue</a></li>
         <li><a href="/code-of-conduct/">Code of Conduct</a></li>
         <li><a href="/ukpa/">UKPA</a></li>
-        <li><a href="/shop/">Shop</a></li>
         <li><a href="/contact/">Contact</a></li>
         <li><a class="cta" href="/tickets/">Tickets</a></li>
       </ul>


### PR DESCRIPTION
Reverts PyconUK/2017.pyconuk.org#45, because it messes up the navbar.