### PR TITLE
Add /cfp/ to unlinked pages

### DIFF
--- a/pyconuk/views.py
+++ b/pyconuk/views.py
@@ -38,6 +38,7 @@ def unlinked_pages(request):
 
     urls = [
         # Add to this as and when required
+        '/cfp/',
     ]
 
     for redirection in Redirection.objects.order_by('key'):


### PR DESCRIPTION
/cfp/ isn't linked to from anywhere on the site, so it currently 404s.  However, it is linked to from UK Python News, which now won't build.