### PR TITLE
Force markdown to recognise URLs

### DIFF
--- a/sessions/talk/a-brief-history-of-markup-languages.md
+++ b/sessions/talk/a-brief-history-of-markup-languages.md
@@ -11,4 +11,5 @@ I hope to touch (briefly) on at least nroff/troff, SGML, HTML, Docbook, TeX and 
 
 I shall probably curse briefly about wiki markups.
 
-The slides, and extended notes, will be available at https://github.com/tibs/markup-history
+The slides, and extended notes, will be available at
+[https://github.com/tibs/markup-history](https://github.com/tibs/markup-history)

--- a/sessions/workshop/an-amble-through-the-history-of-python.md
+++ b/sessions/workshop/an-amble-through-the-history-of-python.md
@@ -14,4 +14,5 @@ The idea is to start at the beginning, and see how far we can get.
 
 Note that this will be the sort of talk where people are welcome to interrupt and ask questions, join in, or even correct me if I've got something wrong(!).
 
-The slides and their notes (with links) are available at https://github.com/tibs/python-history
+The slides and their notes (with links) are available at
+[https://github.com/tibs/python-history](https://github.com/tibs/python-history)


### PR DESCRIPTION
Unfortunately the two "bare" URLs in my talk pages don't show up as such on the actual web site. So I've gone more explicit.