### PR TITLE
Restore previous homepage content

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -2,28 +2,39 @@ title: PyCon UK 2017
 template: index.html
 ---
 
-PyCon UK 2017 is over.  Thank you to everybody who supported the conference!
+<div class="callout">
+  <p>
+    PyCon UK 2017 is over.
+    Thank you to everybody who supported the conference!
+  </p>
 
-Videos of talks are already appearing on [YouTube](https://www.youtube.com/channel/UChA9XP_feY1-1oSy2L7acog), and links to more post-conference resources will appear here soon.
+  <p>Videos of talks are already appearing on <a href="https://www.youtube.com/channel/UChA9XP_feY1-1oSy2L7acog">YouTube</a>, and links to more post-conference resources will appear here soon.</p>
 
-To stay in touch, please sign up to our monthly newsletter:
+  <p>To stay in touch, please sign up to our monthly newsletter:</p>
 
-<!-- Begin MailChimp Signup Form -->
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<div id="mc_embed_signup">
-  <form action="//pyconuk.us14.list-manage.com/subscribe/post?u=96b33657d204fcc7aba284d8a&amp;id=7feb720a8b" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-      <label for="mce-EMAIL">Sign up for monthly news from the UK Python community</label>
-      <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-      <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-      <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_96b33657d204fcc7aba284d8a_7feb720a8b" tabindex="-1" value=""></div>
-      <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-  </form>
+  <!-- Begin MailChimp Signup Form -->
+  <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
+  <div id="mc_embed_signup">
+    <form action="//pyconuk.us14.list-manage.com/subscribe/post?u=96b33657d204fcc7aba284d8a&amp;id=7feb720a8b" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+      <div id="mc_embed_signup_scroll">
+        <label for="mce-EMAIL">Sign up for monthly news from the UK Python community</label>
+        <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
+        <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+        <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_96b33657d204fcc7aba284d8a_7feb720a8b" tabindex="-1" value=""></div>
+        <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
+      </div>
+    </form>
+  </div>
+  <!--End mc_embed_signup-->
+
+  <p>~ The PyCon UK Committee</p>
 </div>
-<!--End mc_embed_signup-->
 
-~ The PyCon UK Committee
+<style>
+  div.callout {
+    font-size: 1.2em;
+  }
+</style>
 
 ---
 

--- a/pages/index.md
+++ b/pages/index.md
@@ -1,12 +1,170 @@
 title: PyCon UK 2017
 template: index.html
 ---
-PyCon UK 2017 is over.  Thank you to everybody who supported the conference!
 
-Videos of talks are already appearing on [YouTube](https://www.youtube.com/channel/UChA9XP_feY1-1oSy2L7acog), and links to more post-conference resources will appear here soon.
+PyCon UK is the annual gathering of the UK Python community and its friends from around the world.
+This year, we return to [Cardiff City Hall](http://www.cardiffcityhall.com/),
+from Thursday 26th to Monday 30th October. *Don't forget that clocks go back
+between Saturday 28th and Sunday 29th October.*
 
-To stay in touch, please sign up to our monthly newsletter:
+**_Sold Out_**: we are completely sold out with over 700 people coming. We regret
+that we have no waiting list. If you are a sponsor or a speaker with a query about
+tickets please contact the [organising committee](/contact/).
 
+**Children's Day Tickets**: We [still have tickets](https://hq.pyconuk.org/children/orders/new/) for the
+[Children's Day](/education/).
+
+**Questions for the Panel Discussions**: We would like to invite attendees to propose questions for the
+three panel discussions via [this form](https://goo.gl/forms/C3UQqjTBH5ZBLFT53).
+
+* * *
+
+# Information for Attendees
+
+You can review your ticket details and the events and meals you've signed up for at
+[your profile](https://hq.pyconuk.org/). You'll need to sign in using the email
+address with which you booked your ticket.
+
+## Registration & Schedule
+
+* The conference runs from 9am to 6.30pm each day.
+* **Registration**: opens each day at 8am but will be available throughout the day.
+* **Picademy**: If you're attending Picademy you need not register with the conference
+  unless you're _also_ attending the conference proper, in which case, please do.
+* **Do not photo me?**: If you would rather not be in people's photographs, please
+  pick up a **yellow** lanyard when you register.
+
+### During the day
+
+* **Schedule**: View the [Schedule](/schedule/) of keynotes, talks, workshops and panels
+* **Poster Session**: During the Saturday lunchtime slots, there will be a Poster Session outside
+  the dining hall. Please stop by and talk to the people displaying posters.
+* **Lightning Talks**: There's a [Lightning Talk](/sessions/talks/lightning-talks/) session at the end of each day.
+  We particularly encourage first-time speakers to submit a talk.
+* **Key-signing party**: There will be a [key-signing party](/sessions/workshops/key-signing-party/) on Friday lunchtime in Room C
+* **Sprints**: [Monday](/schedule/#monday) is a day for [Sprints](/sessions/workshops/sprint/): a chance to collaborate on
+  your own or someone else's Python project.
+
+### Evenings
+
+* **Conference Dinner**: If you've [booked for it](https://hq.pyconuk.org/dinners/conference-dinner/),
+  the Conference Dinner is on Friday at the conference venue itself in the
+  Lower Hall. The bar will be open from 6.30pm and dinner is served at 7.30pm.
+* **Contributors' Dinner**: The invitation-only Contributors' Dinner is on Sunday at the
+  [Clink Restaurant](http://theclinkcharity.org/the-clink-restaurants/cardiff-wales/).
+  You should try to be at the restaurant by 7.15pm to be seated at 7.30pm.
+  If you're a speaker and haven't received an invitation, please [get in touch](/contact/)
+* **Code Dojo**: [Code Dojo](/dojo/) on Thursday from 7pm in the Lower Hall.
+  You'll need to have signed up for this via the booking page early this week.
+  The bar will be open and pizza will be available to buy.
+* **Board Games Evening**: There will be a [Board Games evening](/board-games/) on Saturday from 7pm
+  in the Lower Hall.
+  You'll need to have signed up for this via the booking page early this week.
+  Please bring board games if you have them, we'll be on hand to help match
+  people to games if you don't. The bar will be open and pizza will be
+  available to buy.
+* Please feel free to use the [PyCon UK Slack](https://pyconuk-2017.slack.com)
+  #social channel to organise meetups and events with other conference attendees.
+  _Ticketholders will receive an invitation to join in the week before the conference._
+
+## Venue & Accommodation
+
+* **Venue**: PyCon UK takes place at [Cardiff City Hall](http://www.cardiffcityhall.com/find-us).
+  There are PDF maps of the [Ground](http://www.cardiffcityhall.com/groundfloorplan.pdf)
+  and [First](http://www.cardiffcityhall.com/firstfloorplan.pdf) floors where the
+  conference rooms are situated. There is also an overview of the [City Hall
+  layout](http://www.cardiffcityhall.com/rooms).
+* **Mobility Parking**: If you need to park nearby because of mobility issues,
+  please [contact us](/contact/) and we'll do our best to help.
+* **Parking in Cardiff**: For other parking, you're advised to pre-book via
+  [NCP Cardiff](https://www.ncp.co.uk/parking-solutions/cities/cardiff)
+  or make other parking arrangements.
+* **Accommodation**: If you're having trouble finding somewhere to stay please see the
+  [accommodation page](/accommodation/) as we have made some arrangements
+  with local hostels who may still be able to put you up.
+* **First Aid**: If you need first aid or other medical assistance during the
+  conference, please contact the front desk.
+
+## Communications, Photos &c.
+
+* **Front Desk**: The Front Desk will be staffed for Registration and general information
+  throughout the conference. Please ask there if you need any help.
+* **Announcements**: During the conference the [PyCon UK Slack](https://pyconuk-2017.slack.com)
+  #announcements channel will be used to share announcements and other information.
+  _Ticketholders will receive an invitation to join in the week before the conference._
+* **PyCon UK Twitter**: You can also follow the [PyCon UK Twitter](https://twitter.com/pyconuk)
+  account for conference announcements
+* **#pyconuk**: If you're talking about PyCon UK on social media, please use the tag
+  #pyconuk for consistency.
+* **Photos**: You're welcome to take photos but please be aware that people wearing
+  **yellow** lanyards have requested that their photo not be taken. We ask you
+  to respect people's wishes.
+* **Contact**: For general queries please contact the [organising committee](/contact/)
+
+## Food & Drink
+
+* **Coffee**: Coffee & pastries (including Welsh cakes) will be available before
+  the start of the conference and during the breaks. If you want a proper
+  breakfast you'd do well to explore Cardiff's cafe culture.
+* **Lunch**: The conference ticket includes lunch which will be available between 1pm and 2.30pm.
+  Since we're feeding upwards of 700 people you will be offered a sitting between those times
+  when you register. It will help organise things if you can stick to that sitting
+  but we're not doing retina scans at the start of the dinner queue!
+* **Dinner**: There are two official conference Dinners, one for the whole conference,
+  the other for Contributors (speakers, volunteers etc.). On other nights, or if
+  you have not booked for those dinners, people tend to self-organise into
+  groups. Feel free to use the [PyCon UK Slack Channel](https://pyconuk-2017.slack.com)
+  for this purpose.
+
+## Atmosphere
+
+We very much want PyCon UK to be a welcoming event where everyone feels
+comfortable. Please take the time to read about our approach to
+[Diversity, Accessibility and Inclusion](/diversity-accessibility-inclusion/).
+
+We ask all those attending the conference to respect all other attendees
+and to honour our [Code of Conduct](/code-of-conduct/).
+
+### The Zen of PyCon UK
+It can be intimidating coming to a conference of several hundred people, especially
+when they all seem to be so much more at home than you are. We propose the
+Zen of PyCon UK which we hope newcomers and old hands alike will benefit from:
+
+* Never be afraid to ask someone's name
+* Never be afraid to ask someone's name *again*
+* Never be afraid to join a group
+* Never be slow to welcome someone who's joined your group
+* Never be afraid to leave a group
+* Never be afraid to ask for help, directions, advice, where's the toilet?
+* Never be afraid to respectfully disagree
+* Never be afraid to apologise and/or back down
+* Never be afraid to admit you're wrong, that you don't know, or that you're out of your depth
+* Never be afraid to go in out of your depth
+* Never act surprised just because someone seems not to know something you think they should
+* Never be afraid to take a break
+* Never be afraid to address, politely, negative behaviour or language, whether explicit or implicit
+* Never be afraid to do your own thing, regardless of what the crowd is doing
+
+## Other events at PyCon UK
+
+* [PyData](/pydata/) (Thursday to Sunday) Talks and workshops about data science, put on in collaboration with [PyData London](https://london.pydata.org/). Access is included in the price of the conference ticket.
+
+* [Django Girls](https://djangogirls.org/pyconuk2017/) (Thursday) A beginner-friendly Python and Django workshop designed to inspire women to fall in love with programming. Applications are closed. If you have any questions, please contact the Django Girls organisers by email: [pyconuk@djangogirls.org](mailto:pyconuk@djangogirls.org).
+
+* [Picademy](https://www.raspberrypi.org/training/picademy/) (Thursday and Friday) A professional development programme for teachers, organised by the [Raspberry Pi Foundation](https://www.raspberrypi.org/). Applications are closed. Attendees should already have received their information packs. If you have any questions, please [contact the Raspberry Pi Foundation directly](https://www.raspberrypi.org/contact/).
+
+* [Talks for teachers](/schedule/#saturday) (Saturday) A day of talks in Room D about Python and education. Non-teachers are very welcome!
+
+* [Code Club](/sessions/workshops/code-club/) (Saturday) Coding workshops for kids aged under 13. Led by [Code Club](https://www.codeclub.org.uk/) champions and volunteers, we'll be running activities for young coders' using Python to create games and more. There will also be a special session on programming micro:bits and Adafruit's Circuit Playground Express boards - not to be missed! [Tickets cost £5 and are still on sale!](https://hq.pyconuk.org/children/orders/new/)
+
+* [Raspberry Jam](/sessions/workshops/raspberry-jam/) (Saturday) More coding workshops, for young people aged over 13, or anyone looking to do more advanced projects. The [Raspberry Pi Foundation](https://www.raspberrypi.org/) will be running a Raspberry Jam - and parents and guardians can join in too! We'll be running a variety of digital making activities using Python on the Raspberry Pi. [Tickets cost £5 and are still on sale!](https://hq.pyconuk.org/children/orders/new/)
+
+* [Trans\*Code](/transcode/) (Monday) A day-long hackathon to address issues facing the trans\* and nonbinary community. The day is open to all trans\* and nonbinary people and allies, and we welcome participants from all skill levels and backgrounds.
+
+
+## Useful Links
+
+* [**The PyCon UK Shop**](https://shop.spreadshirt.co.uk/pyconuk/)
 <!-- Begin MailChimp Signup Form -->
 <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
 <div id="mc_embed_signup">

--- a/pages/index.md
+++ b/pages/index.md
@@ -2,6 +2,31 @@ title: PyCon UK 2017
 template: index.html
 ---
 
+PyCon UK 2017 is over.  Thank you to everybody who supported the conference!
+
+Videos of talks are already appearing on [YouTube](https://www.youtube.com/channel/UChA9XP_feY1-1oSy2L7acog), and links to more post-conference resources will appear here soon.
+
+To stay in touch, please sign up to our monthly newsletter:
+
+<!-- Begin MailChimp Signup Form -->
+<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
+<div id="mc_embed_signup">
+  <form action="//pyconuk.us14.list-manage.com/subscribe/post?u=96b33657d204fcc7aba284d8a&amp;id=7feb720a8b" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+    <div id="mc_embed_signup_scroll">
+      <label for="mce-EMAIL">Sign up for monthly news from the UK Python community</label>
+      <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
+      <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+      <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_96b33657d204fcc7aba284d8a_7feb720a8b" tabindex="-1" value=""></div>
+      <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
+    </div>
+  </form>
+</div>
+<!--End mc_embed_signup-->
+
+~ The PyCon UK Committee
+
+---
+
 PyCon UK is the annual gathering of the UK Python community and its friends from around the world.
 This year, we return to [Cardiff City Hall](http://www.cardiffcityhall.com/),
 from Thursday 26th to Monday 30th October. *Don't forget that clocks go back
@@ -165,20 +190,6 @@ Zen of PyCon UK which we hope newcomers and old hands alike will benefit from:
 ## Useful Links
 
 * [**The PyCon UK Shop**](https://shop.spreadshirt.co.uk/pyconuk/)
-<!-- Begin MailChimp Signup Form -->
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<div id="mc_embed_signup">
-  <form action="//pyconuk.us14.list-manage.com/subscribe/post?u=96b33657d204fcc7aba284d8a&amp;id=7feb720a8b" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-      <label for="mce-EMAIL">Sign up for monthly news from the UK Python community</label>
-      <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-      <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-      <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_96b33657d204fcc7aba284d8a_7feb720a8b" tabindex="-1" value=""></div>
-      <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-  </form>
-</div>
-<!--End mc_embed_signup-->
 
 ~ The PyCon UK Committee
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,7 +5,7 @@
   <div class="callout">
     <h1>PyCon UK is your community-led volunteer-run conference</h1>
     <h4>Thursday 26th to Monday 30th October 2017<br />Cardiff City Hall</h4>
-    <a href="#" class="cta">Thank you!</a>
+    <a href="/schedule/" class="cta">View the schedule</a>
   </div>
 
   <div class="image-holder">


### PR DESCRIPTION
This restores all the homepage content deleted in #218 (thus restoring any broken links), and in the spirit of the conference, increases the font size of the "thanks" banner to make it more prominent.

We can decide on a better strategy for managing the homepage later; I’m going to merge by fiat once tests pass so the broken links can be restored quickly. This also addresses my concerns about losing valuable content from the homepage – the Zen of PyCon UK is particularly valuable, IMO.

Resolves #219.